### PR TITLE
Fix linter errors in sidebar

### DIFF
--- a/playground/components/app-sidebar.tsx
+++ b/playground/components/app-sidebar.tsx
@@ -8,8 +8,6 @@ import {
   IconHelp,
   IconInnerShadowTop,
   IconReport,
-  IconSearch,
-  IconSettings,
   IconUsers,
 } from "@tabler/icons-react"
 
@@ -25,7 +23,6 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
-import { availableMemory } from "process"
 
 const data = {
   user: {


### PR DESCRIPTION
## Summary
- remove unused icons and modules from `AppSidebar`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684dc6c1fbfc833284cef91966799ae7