### PR TITLE
Fix Jest config for ts-jest ESM setup

### DIFF
--- a/playground/jest.config.ts
+++ b/playground/jest.config.ts
@@ -6,11 +6,11 @@ const config: Config = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
   },
-  globals: {
-    'ts-jest': {
-      useESM: true,
-    },
+  transformIgnorePatterns: ['/node_modules/(?!(tailrix)/)'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { useESM: true }],
   },
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- update `playground/jest.config.ts` to use modern ts-jest options
- ensure Tailrix is transformed by Jest

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dcf3d60b0833294b58defa5239aef