### PR TITLE
feat: Retain selected tab in URL and reset on navigation

### DIFF
--- a/playground/components/feature-sub-table.tsx
+++ b/playground/components/feature-sub-table.tsx
@@ -38,6 +38,10 @@ export function FeatureSubscriptionTable({
   const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();
+  const tab = searchParams.get("tab");
+  const validTabs = ["features", "subscriptions"];
+  const currentTab = tab && validTabs.includes(tab) ? tab : "features";
+
   const currentUser = users.find(user => user.id === currentUserId);
   const orgList = (currentUser?.organizationNames || []).map((name, index) => ({
     id: currentUser?.organizationIds[index] || "",
@@ -62,9 +66,16 @@ export function FeatureSubscriptionTable({
     router.replace(`${pathname}?${params.toString()}`);
   }
 
+  const handleTabChange = (value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("tab", value);
+    router.replace(`${pathname}?${params.toString()}`);
+  }
+
   return (
     <Tabs
-      defaultValue="features"
+      defaultValue={currentTab}
+      onValueChange={handleTabChange}
       className="w-full flex-col justify-start gap-6"
     >
       <div className="flex items-center justify-between px-4 lg:px-6">

--- a/playground/components/nav-main.tsx
+++ b/playground/components/nav-main.tsx
@@ -26,6 +26,7 @@ export function NavMain({
 
   const onClick = (url: string) => () => {
     const params = new URLSearchParams(searchParams.toString());
+    params.delete("tab"); // Remove the "tab" parameter
     const newUrl = new URL(url, window.location.origin)
     newUrl.search = params.toString()
     router.push(newUrl.toString());


### PR DESCRIPTION
I've implemented functionality to store the active tab in the URL search parameters for components that use tabs (`FeatureSubscriptionTable` and `UserManagementTable`).

- `FeatureSubscriptionTable`:
  - Reads "tab" from URL on load, defaults to "features".
  - Updates "tab" in URL on change.
- `UserManagementTable` (via `user-management/page.tsx`):
  - Reads "tab" from URL on load, defaults to "users".
- `nav-main.tsx`:
  - I modified navigation logic to remove the "tab" parameter when you switch between main sections (Overview, User Management). This allows each section to default to its appropriate tab.

This change ensures that your selected tab state is preserved across page refreshes and that navigating between major app sections correctly resets the tab to the section's default.