### PR TITLE
Fix: Reset organization dropdown when you are selected

### DIFF
--- a/playground/components/feature-sub-table.tsx
+++ b/playground/components/feature-sub-table.tsx
@@ -53,6 +53,7 @@ export function FeatureSubscriptionTable({
   const handleUserSelected = (userId: string) => {
     const params = new URLSearchParams(searchParams.toString());
     params.set("accountId", userId);
+    params.delete("orgId"); // Remove orgId when user changes
     router.replace(`${pathname}?${params.toString()}`);
   }
 


### PR DESCRIPTION
When a new user is selected from the user dropdown, the organization dropdown is now reset to its default state. This is achieved by removing the 'orgId' URL parameter in the `handleUserSelected` function within the `FeatureSubscriptionTable` component.